### PR TITLE
TypeError [ERR_INVALID_ARG_TYPE]: The "data"

### DIFF
--- a/poeditorial.js
+++ b/poeditorial.js
@@ -147,10 +147,11 @@ async function uploadFile(projectId, language, filePath, updating, optionalParam
 async function downloadFile(url, destination = undefined) {
     const p = rp.get(url, {
         baseUrl: null,
-    })
+        json: false
+    });
 
     if(destination){
-        p.then( response => {
+        p.then(response => {
             fs.writeFileSync(destination, response);
             return response;
         })


### PR DESCRIPTION
I'm sorry for the last changes I made - it was not fully working
```
node:fs:2435
    validateStringAfterArrayBufferView(data, 'data');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object
    at Object.writeFileSync (node:fs:2435:5)
    at ***\node_modules\poeditorial\poeditorial.js:154:16
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
For download we need a raw data - not a JSON - poeditor sends a correct format specified in configuration

On line 11 there is a default configured `json: true,` - so in download we set it to false instead.

I tested it locally - works.